### PR TITLE
Filter out non-fashion images

### DIFF
--- a/fashion-messaging-app-ui/src/App.jsx
+++ b/fashion-messaging-app-ui/src/App.jsx
@@ -9,16 +9,13 @@ import LoginForm from './components/LoginForm/LoginForm';
 import SignupForm from './components/SignupForm/SignupForm';
 import Homepage from './components/Homepage/Homepage';
 
-
 const API_KEY = "06ZcwjgbmJBM8T2TxLUZ5iwdXXGxiAgz0Z018b7QPKwR1ExipkFjaAuw";
 const clientAPI = createClient(API_KEY);
 const defaultQuery = "Fashion";
-const PHOTOS = 100;
+const PHOTOS = 1;
 
 export default function App() {
-  
   const [loading, setLoading] = useState(true);
-
   const [user, setUser] = useState(() => {
     return null;
 });
@@ -28,42 +25,58 @@ export default function App() {
   };
   const [photos, setPhotos] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
+  const [noResults, setNoResults] = useState(false);
 
-  useEffect(() => {
+useEffect(() => {
+  setLoading(true);
 
-    setLoading(true)
-    
-    const query = searchQuery || defaultQuery;
-    clientAPI.photos
-      .search({ query, per_page: PHOTOS })
-      .then(response => {
-        setPhotos(response.photos);
-        setLoading(false)
-      })
-      .catch(error => {
-        console.error("Error fetching photos:", error);
-        setLoading(false);
-      });
-      localStorage.setItem('user', JSON.stringify(user));
+  const query = searchQuery || defaultQuery;
+  clientAPI.photos
+    .search({ query, per_page: PHOTOS })
+    .then(async response => { 
+      setLoading(false);
 
-  },[searchQuery]);
-    var myHeaders = new Headers();
-    myHeaders.append("x-api-key", "c8dd1e873a6bde14651aa42ee44752f41c8da53b0aa4bfb5205d25805826f628");
-    
-    var formdata = new FormData();
-    formdata.append("image_url", "https://cdn.shopify.com/s/files/1/0266/6276/4597/products/300936541TANGERINE_2_1024x1024.jpg?v=1682513958");
-    
-    var requestOptions = {
-      method: 'POST',
-      headers: myHeaders,
-      body: formdata,
-    };
-    
-    fetch('https://cloudapi.lykdat.com/v1/detection/items', requestOptions)
-      .then(response => response.text())
-      .then(result => console.log(result))
-      .catch(error => console.log('error', error));
-  
+      var myHeaders = new Headers();
+      myHeaders.append("x-api-key", "1a4092c4563cc701627b1616fa6053190c6b538fd82b828d3fe20416bcc3dd3e");
+
+      let fetchPromises = await Promise.all(response.photos.map(async photo => { 
+        var formdata = new FormData();
+        formdata.append("image_url", photo.src.original);
+
+        var requestOptions = {
+          method: 'POST',
+          headers: myHeaders,
+          body: formdata,
+        };
+
+        try {
+          const fetchResponse = await fetch('https://cloudapi.lykdat.com/v1/detection/items', requestOptions);
+          const result = await fetchResponse.json();
+
+          if (result.data.detected_items.length === 0) {
+          } else {
+            result.data.detected_items.forEach(item => {
+            });
+
+            return photo;
+          }
+        } catch (error) {
+          console.error('error', error);
+        }
+      }));
+
+      const fashionPhotos = fetchPromises.filter(photo => photo !== undefined);
+      setPhotos(fashionPhotos);
+      setNoResults(fashionPhotos.length === 0);
+    })
+    .catch(error => {
+      console.error("Error fetching photos:", error);
+      setLoading(false);
+    });
+
+  localStorage.setItem('user', JSON.stringify(user));
+}, [searchQuery]);
+
 
   const handleSearch = query => {
     setSearchQuery(query);
@@ -76,15 +89,15 @@ export default function App() {
         <p>Loading...</p> 
       </div>
     );
-  }
+  } 
 
-
+  
   return (
     <div className="app">
       <UserContext.Provider value={{ user, updateUser }}>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={ <Homepage photos={photos} handleSearch={handleSearch} /> } />
+          <Route path="/" element={ <Homepage photos={photos} handleSearch={handleSearch} noResults={noResults}  /> } />
           <Route path="/post" element={ <Main /> } />
           <Route path="/login" element={<LoginForm />} />
           <Route path="/signup" element={<SignupForm />} />

--- a/fashion-messaging-app-ui/src/components/FashionItems/FashionItems.jsx
+++ b/fashion-messaging-app-ui/src/components/FashionItems/FashionItems.jsx
@@ -1,12 +1,15 @@
+
 import * as React from "react";
 import "./FashionItems.css";
 
-export default function Outfits({ photos }) {
+export default function Outfits({ photos, noResults }) {
     return (
       <div className="photo">
-        {photos.map(photo => (
-          <img key={photo.id} src={photo.src.original} alt= "" />
-        ))}
+        {noResults ? <p>No results</p> : 
+          photos.map(photo => (
+            <img key={photo.id} src={photo.src.original} alt="" />
+          ))
+        }
       </div>
     );
-  }
+}

--- a/fashion-messaging-app-ui/src/components/Homepage/Homepage.jsx
+++ b/fashion-messaging-app-ui/src/components/Homepage/Homepage.jsx
@@ -4,7 +4,7 @@ import Search from "../Search/Search";
 import "./Homepage.css";
 import { Link } from "react-router-dom";
 
-function Homepage({photos, handleSearch}) {
+function Homepage({photos, handleSearch, noResults}) {
   return (
     <div>
         <div className="container">
@@ -14,7 +14,7 @@ function Homepage({photos, handleSearch}) {
             <Search onSearch={handleSearch} />
         
         </div>
-            <FashionItems photos={photos} />
+            <FashionItems photos={photos} noResults={noResults} />
     </div>
   );
 }


### PR DESCRIPTION
**Description**

- Add functionality that filters non-fashion images from the api
- Pass the url for each object in my first API into the url for the second API which is a fashion API that checks the detection confidence for fashion. I will work on caching in my next pull request

**Milestones**

- Set up API calls from Lykdat API
- Add promise.all to help with asynchronous calls for the two APIs. This avoids the component from re-rendering and it allows my state to be updated once 
- Use if-else statement to filter out empty objects which are non-fashion items 
- Render the images that have fashion and return “No Results” for non-fashion
- Use useState to modify the state for the fashion images and to return “No Results” for fashion images

Here is a preview of my website: 
In the first two images I searched for non-fashion images and they returned no-results but when I search for a fashion item it returns fashion items 
![Image 7-25-23 at 8 01 PM](https://github.com/preciousonah/Fashion-Messaging-Capstone-Project-/assets/121525219/2b5e951c-72cd-4d74-8377-bdabb85fbbbd)
![Image 7-25-23 at 8 01 PM](https://github.com/preciousonah/Fashion-Messaging-Capstone-Project-/assets/121525219/5ef37040-a8e0-4e42-887e-8ba4698c713c)
![Image 7-25-23 at 8 01 PM](https://github.com/preciousonah/Fashion-Messaging-Capstone-Project-/assets/121525219/3b1f3528-8973-48b0-9d7d-fa309aa17b13)

