### PR TITLE
Amend filter process for searchResults

### DIFF
--- a/fashion-messaging-app-api/server.js
+++ b/fashion-messaging-app-api/server.js
@@ -22,7 +22,7 @@ const app = express();
 const API_KEY = "06ZcwjgbmJBM8T2TxLUZ5iwdXXGxiAgz0Z018b7QPKwR1ExipkFjaAuw";
 const clientAPI = createClient(API_KEY);
 const defaultQuery = "Fashion";
-const PHOTOS = 2;
+const PHOTOS = 10;
 
 let cache = new Map();
 app.use(cors({
@@ -91,52 +91,58 @@ app.get('/posts', async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 });
-app.get('/photos', async (req, res) => {
-  const query = req.query.search || defaultQuery;
 
-  
-  try {
-    const response = await clientAPI.photos.search({ query, per_page: PHOTOS, page: 1});
+    app.get('/photos', async (req, res) => {
+      const query = req.query.search || defaultQuery;
+      const perPage = (query === defaultQuery) ? 20 : PHOTOS; 
     
-    let fetchPromises = response.photos.map(async photo => {
-      if (cache.has(photo.src.original)) {
-        return cache.get(photo.src.original);
-      
-      } else {
-        var myHeaders = new Headers();
-        myHeaders.append("x-api-key", "7008b5da328806c39a5561c3d51339c18dbb66dcd8bbfeebca80f0a96c44c332");           
-                     
-
-        var formdata = new FormData();
-        formdata.append("image_url", photo.src.original);
-      
-        var requestOptions = {
-          method: 'POST',
-          headers: myHeaders,
-          body: formdata,
-        };
-
-        try {
-          const fetchResponse = await fetch('https://cloudapi.lykdat.com/v1/detection/items', requestOptions);
-          if (fetchResponse.status === 400) {
-            throw new Error('Image size too large for the API.');
+      try {
+        const response = await clientAPI.photos.search({ query, per_page: perPage, page: 1});
+        let fetchPromises = response.photos.map(async photo => {
+          if (cache.has(photo.src.original)) {
+            return cache.get(photo.src.original);
+            
+          } else if (query !== defaultQuery) { 
+           
+            var myHeaders = new Headers();
+            myHeaders.append("x-api-key", "7008b5da328806c39a5561c3d51339c18dbb66dcd8bbfeebca80f0a96c44c332");      
+            
+          
+            var formdata = new FormData();
+            formdata.append("image_url", photo.src.original);
+    
+            var requestOptions = {
+              method: 'POST',
+              headers: myHeaders,
+              body: formdata,
+            };
+    
+            try {
+              const fetchResponse = await fetch('https://cloudapi.lykdat.com/v1/detection/items', requestOptions);      
+              if (fetchResponse.status === 400) {
+                throw new Error('Image size too large for the API.');
+              }
+              const result = await fetchResponse.json();
+    
+              if (result.data.detected_items.length > 0) {
+                cache.set(photo.src.original, photo);
+                return photo;
+              }
+    
+            } catch (error) {
+              console.error('error', error);
+              return null;
+            }
           }
-          const result = await fetchResponse.json();
-
-          if (result.data.detected_items.length > 0) {
-            cache.set(photo.src.original, photo);
+          else if (query === defaultQuery) {
+            cache.set(photo.src.original, photo); 
             return photo;
           }
-
-        } catch (error) {
-          console.error('error', error);
-          return null;
-        }
-      }
-    });
-
-    const fashionPhotos = await Promise.all(fetchPromises);
-    const validPhotos = fashionPhotos.filter(photo => photo !== undefined && photo !== null);
+        });
+    
+        const fashionPhotos = await Promise.all(fetchPromises);
+        const validPhotos = fashionPhotos.filter(photo => photo !== undefined && photo !== null);
+    
     for (let photo of validPhotos) {
       let searchResult = await SearchResult.findOne({
         where: { 
@@ -172,12 +178,12 @@ app.get('/recommendations', async (req, res) => {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
-    let recommendations = [];  
+    let recommendations = [];    
     const frequentSearch = await SearchResult.findOne({
       where: { 
         userId: req.session.user.id,
         searchTerm: {
-          [Op.not]: defaultQuery  
+          [Op.not]: defaultQuery 
         }
       },
       order: [['searchCount', 'DESC']],
@@ -186,7 +192,7 @@ app.get('/recommendations', async (req, res) => {
       where: { 
         userId: req.session.user.id,
         searchTerm: {
-          [Op.not]: defaultQuery 
+          [Op.not]: defaultQuery  
         }
       },
       order: [['createdAt', 'DESC']],
@@ -211,13 +217,11 @@ app.get('/recommendations', async (req, res) => {
       order: [['createdAt', 'DESC']],
     });
 
-
     if (latestPost) {
       const responseLatestPost = await clientAPI.photos.search({ 
         query: latestPost.title,  
         per_page: PHOTOS 
       });
-
       responseLatestPost.photos.forEach(photo => {
         photo.source = "latest post";
       });
@@ -225,25 +229,22 @@ app.get('/recommendations', async (req, res) => {
       recommendations.push(...responseLatestPost.photos);
     }
 
-   
     if (!frequentSearch && !lastSearch && !popularSearch) {
       return res.json([]);  
     }
 
-    
     if (frequentSearch) {
       const responseFrequentSearch = await clientAPI.photos.search({ 
         query: frequentSearch.searchTerm, 
         per_page: PHOTOS 
-      });
-     
+      }); 
+
       responseFrequentSearch.photos.forEach(photo => {
         photo.source = "most frequent search";
       });
       recommendations.push(...responseFrequentSearch.photos);
     }
 
-    
     if (lastSearch && (!frequentSearch || (frequentSearch && frequentSearch.searchTerm !== lastSearch.searchTerm))) {
       const responseLastSearch = await clientAPI.photos.search({ 
         query: lastSearch.searchTerm, 
@@ -260,8 +261,6 @@ app.get('/recommendations', async (req, res) => {
         query: popularSearch.searchTerm, 
         per_page: PHOTOS 
       });
-
-  
       responsepopularSearch.photos.forEach(photo => {
         photo.source = "popular search";
       });


### PR DESCRIPTION
**Description**

Amend the non-fashion filter by excluding fashion from the filtering process and returning it directly in the website. This also fixes part of the rate-limit issue with the second API

**Milestones**

- Wrote logic that excludes the default query fashion from being filtered
- Cache the fashion items
- Display more photos in the frontend 
Here is a preview of my website:
![Image 8-2-23 at 4 55 PM](https://github.com/preciousonah/Fashion-Messaging-Capstone-Project-/assets/121525219/47d68250-f1fb-449f-833b-cf6cd778f246)


